### PR TITLE
Separate tmp files for every process/worker

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,12 @@ authors = ["Andreas Scheidegger <andreas.scheidegger@eawag.ch> and contributors"
 version = "0.3.0"
 
 [deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Poppler_jll = "9c32591e-4766-534b-9725-b71a8799265b"
 
 [compat]
-julia = "1.6"
 Poppler_jll = "^21.9"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/PDFmerger.jl
+++ b/src/PDFmerger.jl
@@ -128,11 +128,11 @@ end
   split_pdf(file::AbstractString; cleanup::Bool = false)
 ```
 
-Split a pdf document in seperated pages.
+Split a pdf document in separated pages.
 
 ## Arguments
 
-- `file`: name of file to spitted
+- `file`: name of file to be splitted
 - `cleanup`: if `true`, `file` is deleted after splitting
 """
 function split_pdf(file::AbstractString; cleanup=false)
@@ -142,8 +142,8 @@ function split_pdf(file::AbstractString; cleanup=false)
     n = n_pages(file) |> ndigits
     numberformat = n > 1 ? "%0$(n)d" : "%d"
 
-    pdfseparate() do seperate
-        run(`$seperate $file $(file_no_ending)_$numberformat.pdf`)
+    pdfseparate() do separate
+        run(`$separate $file $(file_no_ending)_$numberformat.pdf`)
     end
 
     if cleanup


### PR DESCRIPTION
Hey,

very helpful package!

I run simulations in Julia and use PDFmerger.jl to create multi-page PDFs with descriptive statistics of the simulation. I tried now to run several simulations on different processes/workers, which, however, resulted in errors in the `appendPDF!` function. It seems that the multiple processes are interfering with the temporary files of other processes.

So I created a quick fix in that the temporary files now have a identifier of the process that created them. I tested the change locally with my simulation with multiple processes and the fix seems to work fine.
The unit tests pass fine.

Cheers,

Oliver

PS: I also fixed some typos in the other commit.